### PR TITLE
FIX: limit latitude/longitude to their maximum allowed values

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2020-2021, QIIME 2 development team.
+Copyright (c) 2022, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/q2_coordinates/__init__.py
+++ b/q2_coordinates/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_coordinates/_format.py
+++ b/q2_coordinates/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_coordinates/_transformer.py
+++ b/q2_coordinates/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_coordinates/_type.py
+++ b/q2_coordinates/_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_coordinates/_utilities.py
+++ b/q2_coordinates/_utilities.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_coordinates/_utilities.py
+++ b/q2_coordinates/_utilities.py
@@ -67,11 +67,11 @@ def get_map_params(image='StamenTerrain', color_palette=None):
 
 
 def get_max_extent(latitude, longitude):
-    lat_0 = latitude.min() - latitude.std()
-    lat_1 = latitude.max() + latitude.std()
-    lon_0 = longitude.min() - longitude.std()
-    lon_1 = longitude.max() + longitude.std()
-    return lat_0, lat_1, lon_0, lon_1
+    lat_0 = latitude.min() - 0.15*latitude.std()
+    lat_1 = latitude.max() + 0.15*latitude.std()
+    lon_0 = longitude.min() - 0.15*longitude.std()
+    lon_1 = longitude.max() + 0.15*longitude.std()
+    return max(lat_0, -90), min(lat_1, 90), max(lon_0, -180), min(lon_1, 180)
 
 
 def plot_basemap(latitude, longitude, image, color_palette=None):

--- a/q2_coordinates/mapper.py
+++ b/q2_coordinates/mapper.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_coordinates/plugin_setup.py
+++ b/q2_coordinates/plugin_setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_coordinates/qtrees.py
+++ b/q2_coordinates/qtrees.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_coordinates/stats.py
+++ b/q2_coordinates/stats.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_coordinates/tests/__init__.py
+++ b/q2_coordinates/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_coordinates/tests/test_coordinates.py
+++ b/q2_coordinates/tests/test_coordinates.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_coordinates/tests/test_mapper.py
+++ b/q2_coordinates/tests/test_mapper.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_coordinates/tests/test_quadtree.py
+++ b/q2_coordinates/tests/test_quadtree.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_coordinates/tests/test_quadtree_plugin.py
+++ b/q2_coordinates/tests/test_quadtree_plugin.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_coordinates/tests/test_stats.py
+++ b/q2_coordinates/tests/test_stats.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_coordinates/tests/test_utilities.py
+++ b/q2_coordinates/tests/test_utilities.py
@@ -5,10 +5,10 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+
 import unittest
 
 import pandas as pd
-import qiime2
 
 from q2_coordinates._utilities import get_max_extent
 

--- a/q2_coordinates/tests/test_utilities.py
+++ b/q2_coordinates/tests/test_utilities.py
@@ -1,0 +1,40 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2022, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+import unittest
+
+import pandas as pd
+import qiime2
+
+from q2_coordinates._utilities import get_max_extent
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_get_max_extent_1(self):
+        lat = pd.Series([-66.0, -64.0, -62.0])
+        lon = pd.Series([26.0, 28.0, 30.0])
+
+        obs = get_max_extent(lat, lon)
+        exp = (-66.3, -61.7, 25.7, 30.3)
+        self.assertTupleEqual(obs, exp)
+
+    def test_get_max_extent_2(self):
+        lat = pd.Series([66.0, 64.0, 62.0])
+        lon = pd.Series([-26.0, -28.0, -30.0])
+
+        obs = get_max_extent(lat, lon)
+        exp = (61.7, 66.3, -30.3, -25.7)
+        self.assertTupleEqual(obs, exp)
+
+    def test_get_max_extent_3(self):
+        lat = pd.Series([-88.0, 10.0, 82.0])
+        lon = pd.Series([-175.0, 15.5, 168.4])
+
+        obs = get_max_extent(lat, lon)
+        exp = (-90, 90, -180, 180)
+        self.assertTupleEqual(obs, exp)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020-2021, QIIME 2 development team.
+# Copyright (c) 2022, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #


### PR DESCRIPTION
It turns out that sometimes, when the range of coordinates is very wide, the calculated map extent is much higher than what is actually allowed. That results in some NaN values calculated by OpenLayers and breaks the visualization.

This PR fixes that by:
1. preventing generation of too high extent values (using only a fraction of stdev)
2. in case still necessary, cropping the ranges to their maximum allowed values

Additionally, copyright headers are updated in a separate commit to reflect year change 🕐 .  

Closes #24. 